### PR TITLE
refactor: 페이지별로 선언되던 outlet context 및 navigate 함수화

### DIFF
--- a/src/main/frontend/src/hooks/useNavigator.jsx
+++ b/src/main/frontend/src/hooks/useNavigator.jsx
@@ -1,0 +1,13 @@
+import { useNavigate, useOutletContext } from "react-router-dom";
+
+export function useGoHome() {
+  const { handleHidden } = useOutletContext();
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    handleHidden();
+    navigate("/");
+  };
+
+  return { handleClick };
+}

--- a/src/main/frontend/src/hooks/useProducts.jsx
+++ b/src/main/frontend/src/hooks/useProducts.jsx
@@ -9,7 +9,6 @@ import {
   getCustomFoods,
   submitFoods,
 } from "../api/Products";
-import { useNavigate } from "react-router-dom";
 import { useState } from "react";
 
 export function useMachines() {
@@ -90,18 +89,12 @@ export function useFoods() {
   return { productsQuery, setProducts, success, handleSubmit };
 }
 
-export function useCustomProducts({ location, handleHidden, setProductsTemp }) {
+export function useCustomProducts({ location, setProductsTemp }) {
   const [selectManager, setSelectManager] = useState("");
   const [result, setResult] = useState(false);
   const [loading, setLoading] = useState(false);
   const [products, setProducts] = useState([]);
   const [warning, setWarning] = useState(false);
-  const navigate = useNavigate();
-
-  const handleClick = () => {
-    handleHidden();
-    navigate("/");
-  };
 
   const handleWarning = () => {
     setWarning(true);
@@ -134,7 +127,6 @@ export function useCustomProducts({ location, handleHidden, setProductsTemp }) {
   };
 
   return {
-    handleClick,
     selectManager,
     setSelectManager,
     handleSubmit,

--- a/src/main/frontend/src/pages/CustomFoods.jsx
+++ b/src/main/frontend/src/pages/CustomFoods.jsx
@@ -1,19 +1,13 @@
 import React from "react";
-import { useOutletContext, useNavigate } from "react-router-dom";
 import styles from "./CustomMachines.module.css";
 import { useFoods } from "./../hooks/useProducts";
 import CustomProducts from "./../components/CustomProducts";
 import Banner from "./../components/Banner";
 import Button from "../components/Button";
+import { useGoHome } from "../hooks/useNavigator";
 
 export default function CustomFoods() {
-  const { handleHidden } = useOutletContext();
-
-  const navigate = useNavigate();
-  const handleClick = () => {
-    handleHidden();
-    navigate("/");
-  };
+  const { handleClick } = useGoHome();
 
   const {
     productsQuery: { isLoading, error, data: foods },

--- a/src/main/frontend/src/pages/CustomMachines.jsx
+++ b/src/main/frontend/src/pages/CustomMachines.jsx
@@ -1,18 +1,13 @@
-import React, { useState } from "react";
-import { useOutletContext, useNavigate } from "react-router-dom";
+import React from "react";
 import CustomProducts from "./../components/CustomProducts";
 import styles from "./CustomMachines.module.css";
 import { useMachines } from "./../hooks/useProducts";
 import Banner from "./../components/Banner";
 import Button from "../components/Button";
+import { useGoHome } from "../hooks/useNavigator";
 
 export default function InputMachines() {
-  const { handleHidden } = useOutletContext();
-  const navigate = useNavigate();
-  const handleClick = () => {
-    handleHidden();
-    navigate("/");
-  };
+  const { handleClick } = useGoHome();
 
   const {
     productsQuery: { isLoading, error, data: machines },

--- a/src/main/frontend/src/pages/InputFoods.jsx
+++ b/src/main/frontend/src/pages/InputFoods.jsx
@@ -1,20 +1,18 @@
 import React, { useEffect } from "react";
-import { useOutletContext, useLocation } from "react-router-dom";
-import {
-  useCustomFoods,
-  useCustomMachines,
-  useCustomProducts,
-} from "./../hooks/useProducts";
+import { useLocation } from "react-router-dom";
+import { useCustomFoods, useCustomProducts } from "./../hooks/useProducts";
 import Banner from "./../components/Banner";
 import InputProducts from "./../components/InputProducts";
 import ManagerList from "./../components/ManagerList";
 import Button from "../components/Button";
 import styles from "./InputFoods.module.css";
 import Modal from "../components/Modal";
+import { useGoHome } from "../hooks/useNavigator";
 
 export default function InputFoods() {
   const location = useLocation();
-  const { handleHidden } = useOutletContext();
+
+  const { handleClick } = useGoHome();
 
   const {
     productsQuery: { isLoading, error, data },
@@ -31,8 +29,7 @@ export default function InputFoods() {
     setResult,
     selectManager,
     setSelectManager,
-    handleClick,
-  } = useCustomProducts({ location, handleHidden, setProductsTemp });
+  } = useCustomProducts({ location, setProductsTemp });
 
   useEffect(() => {
     setProducts(data?.customFood);

--- a/src/main/frontend/src/pages/InputMachines.jsx
+++ b/src/main/frontend/src/pages/InputMachines.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { useOutletContext, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { useCustomMachines, useCustomProducts } from "./../hooks/useProducts";
 import InputProducts from "./../components/InputProducts";
 import Banner from "./../components/Banner";
@@ -7,10 +7,12 @@ import ManagerList from "./../components/ManagerList";
 import Button from "../components/Button";
 import styles from "./InputMachines.module.css";
 import Modal from "../components/Modal";
+import { useGoHome } from "../hooks/useNavigator";
 
 export default function InputMachines() {
   const location = useLocation();
-  const { handleHidden } = useOutletContext();
+
+  const { handleClick } = useGoHome();
 
   const {
     productsQuery: { isLoading, error, data },
@@ -26,15 +28,12 @@ export default function InputMachines() {
     setProducts,
     selectManager,
     setSelectManager,
-    handleClick,
     setResult,
-  } = useCustomProducts({ location, handleHidden, setProductsTemp });
+  } = useCustomProducts({ location, setProductsTemp });
 
   useEffect(() => {
     setProducts(data?.customMachine);
   }, [data]);
-
-  console.log(products);
 
   return (
     <>

--- a/src/main/frontend/src/pages/SelectManagers.jsx
+++ b/src/main/frontend/src/pages/SelectManagers.jsx
@@ -1,13 +1,12 @@
-import { useOutletContext, useNavigate } from "react-router-dom";
 import styles from "./SelectManagers.module.css";
 import { PiTrashBold } from "react-icons/pi";
 import { RiArrowGoBackFill } from "react-icons/ri";
 import { AiOutlineEnter } from "react-icons/ai";
 import { useManagers } from "./../hooks/useManagers";
+import { useGoHome } from "../hooks/useNavigator";
 
 export default function SelectManagers() {
-  const { handleHidden } = useOutletContext();
-  const navigate = useNavigate();
+  const { handleClick } = useGoHome();
 
   const {
     managersQuery: { isLoading, error, data: initialManagers },
@@ -16,11 +15,6 @@ export default function SelectManagers() {
     handleSubmit,
     handleDelete,
   } = useManagers();
-
-  const handleClick = () => {
-    handleHidden();
-    navigate("/");
-  };
 
   return (
     <>


### PR DESCRIPTION
### 📝 Description
페이지별로 인덱스 페이지로 이동하기 위해 선언되어있던 navigate 및 화면을 hidden 시키는 함수를 하나의 훅으로 관리하도록 변경했습니다.
